### PR TITLE
docker: add docker network connectivity

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 status_go_service_name: 'status-go'
 status_go_service_path: '/docker/{{ status_go_service_name }}'
 status_go_service_compose: '{{ status_go_service_path }}/docker-compose.yml'
+status_go_docker_network_name: '{{ gorush_docker_network_name }}'
 
 # Options: ERROR|WARN|INFO|DEBUG|TRACE
 status_go_log_level: 'INFO'

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -1,4 +1,9 @@
 ---
+networks:
+  default:
+    name: '{{ status_go_docker_network_name }}'
+    external: true
+
 services:
   node:
     container_name: '{{ status_go_node_cont_name }}'


### PR DESCRIPTION
Configure status-go container to use shared `gorush` network.

Ref.: 
- https://github.com/status-im/infra-push-notify/issues/10
- https://github.com/status-im/infra-push-notify/pull/12